### PR TITLE
Add button component and toolinformation component

### DIFF
--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -1,0 +1,11 @@
+import React from 'react'
+
+const Button = () => {
+  return (
+    <button className='createButton'>
+        Reparatie aanmelden    
+    </button>
+  )
+}
+
+export default Button


### PR DESCRIPTION
Hi all,

I added a button component which is reusable for other add buttons like adding an article. This button component is part of the toolinformation component. This component shows which tool you are using, with the addButton, for adding (in this case) a new reparation. 

@Prupke can you please check if there are no conflicts with your work ?